### PR TITLE
Analyze fix

### DIFF
--- a/apkInspector/extract.py
+++ b/apkInspector/extract.py
@@ -1,3 +1,4 @@
+import logging
 import zlib
 import os
 
@@ -50,9 +51,13 @@ def extract_file_based_on_header_info(apk_file, local_header_info, central_direc
         cur_loc = apk_file.tell()
         try:
             compressed_data = apk_file.read(compressed_size)
-            extracted_data = zlib.decompress(compressed_data, -15)
+            c_obj = zlib.decompressobj(-15)
+            extracted_data = c_obj.decompress(compressed_data)
+            if not c_obj.eof or c_obj.unused_data or c_obj.unconsumed_tail:
+                raise ValueError("Invalid or non-pure deflate")
             indicator = 'DEFLATED_TAMPERED'
-        except:
+        except Exception as e:
+            logging.debug(e)
             apk_file.seek(cur_loc)
             compressed_data = apk_file.read(uncompressed_size)
             extracted_data = compressed_data

--- a/apkInspector/indicators.py
+++ b/apkInspector/indicators.py
@@ -122,13 +122,10 @@ def process_elements_indicators(file):
         _type, _header_size, _size = struct.unpack('<HHL', file.read(8))
         file.seek(cur_pos)
         if not (min_size <= _header_size <= _size):
-            file.seek(cur_pos + 1)
-            dummy_data_between_elements = True
-            continue
-        if _type == 257 and _size < min_size:
-            wrong_end_namespace_size = True
-            if file.getbuffer().nbytes <= cur_pos + 24:
-                break
+            if _type == 257 and _size < min_size:
+                wrong_end_namespace_size = True
+                file.read(24)
+                continue
             file.seek(cur_pos + 1)
             dummy_data_between_elements = True
             continue


### PR DESCRIPTION
 - fixes indicators accordingly to issue 41, so it can accommodate more chunk types
 - updates extraction for edge case when zlib did not throw `'Error -3 while decompressing data: invalid stored block lengths` for STORED data and therefore were treated as DEFLATED.