### PR TITLE
Improve obfuscated manifests parsing

### DIFF
--- a/apkInspector/axml.py
+++ b/apkInspector/axml.py
@@ -785,11 +785,8 @@ def process_attributes(attributes, string_list, ns_dict):
             # the public.xml. It falls outside the scope of the tool, so I am not going to solve it for now.
             name = f'Unknown_Attribute_Name_{random.randint(1000, 9999)}'
         if "\n" in name:
-            # may be obfuscated attribute - see REAndroid/APKEditor tool
-            # https://github.com/REAndroid/APKEditor
-            logging.warning(f"Skip attribute with name {name!r}")
+            # may be obfuscated attribute - https://github.com/REAndroid/APKEditor
             continue
-   
         if attr.typed_value_datatype == 1:  # reference type
             value = f"@{attr.typed_value_data}"
         elif attr.typed_value_datatype == 3:  # string type


### PR DESCRIPTION
Hello, i'm a virus analyst and found that ApkInspector can't read obfuscated AndroidManifest, guarded by [REAndroid/APKEditor](https://github.com/REAndroid/APKEditor). 

REAndroid/APKEditor repack apk and change AndroidManifest:
- adds dummy attributes in XmlEntries with broken names like ' >\n  </manifest>\n  android:name'
- adds gap in XmlStartTag - change `attr_start` to non standard (more than 20 bytes).
- changes attributes size to non standard (more than 20 bytes).

I've added to `axml.py` few lines of code that
1. Add checks for attr_size - logging if unusual size found.
1. Add checks for attr_start - skip gaps if found, logging.
1. Add checks for attribute name. Skip if '\n' in name was found and log it.

I'm attaching guarded by APKEditor legal APK (not malicious) and obfuscated AndroidManifest from that.

- [clean_AndroidManifest.xml](https://github.com/user-attachments/files/22921886/clean_AndroidManifest.xml)
- [obfuscated_AndroidManifest.xml](https://github.com/user-attachments/files/22921887/obfuscated_AndroidManifest.xml)

- [sms.apk.zip](https://github.com/user-attachments/files/22921903/sms.apk.zip) - it's APK, just remove ZIP extention from name
- [sms_protected.apk.zip](https://github.com/user-attachments/files/22921905/sms_protected.apk.zip) - the same

